### PR TITLE
clean go build files after compiling yay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,7 @@ RUN         pushd /tmp && \
             popd && \
             rm --force --recursive yay && \
             popd && \
-            rm ~/.cache/go-build -rf && \
+            rm ~/.cache/go-build --force --recursive && \
             clean-up
             # endregion
             # region install "gpgdir"

--- a/Dockerfile
+++ b/Dockerfile
@@ -201,6 +201,7 @@ RUN         pushd /tmp && \
             popd && \
             rm --force --recursive yay && \
             popd && \
+            rm ~/.cache/go-build -rf && \
             clean-up
             # endregion
             # region install "gpgdir"

--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,7 @@ RUN         pushd /tmp && \
             popd && \
             rm --force --recursive yay && \
             popd && \
-            rm ~/.cache/go-build --force --recursive && \
+            rm --force --recursive ~/.cache/go-build && \
             clean-up
             # endregion
             # region install "gpgdir"


### PR DESCRIPTION
This might save around 80 MB unused space.